### PR TITLE
Make `gpio::Alternate` generic over output mode

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -61,8 +61,11 @@ pub enum SignalEdge {
 }
 
 /// Altername Mode (type state)
-pub struct Alternate<const A: u8>;
-pub struct AlternateOD<const A: u8>;
+pub struct Alternate<const A: u8, MODE=PushPull> {
+    _mode: PhantomData<MODE>,
+}
+
+pub type AlternateOD<const A: u8> = Alternate<A, OpenDrain>;
 
 pub const AF0: u8 = 0;
 pub const AF1: u8 = 1;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -205,8 +205,6 @@ use crate::time::{Hertz, NanoSecond, U32Ext};
     feature = "stm32g484"
 ))]
 use crate::gpio::gpiog::*;
-#[cfg(feature = "pwm-open-drain")]
-use crate::gpio::AlternateOD;
 #[cfg(any(
     feature = "stm32g471",
     feature = "stm32g473",
@@ -215,7 +213,7 @@ use crate::gpio::AlternateOD;
     feature = "stm32g484"
 ))]
 use crate::gpio::AF14;
-use crate::gpio::{gpioa::*, gpiob::*, gpioc::*, gpiod::*, gpioe::*, gpiof::*};
+use crate::gpio::{self, gpioa::*, gpiob::*, gpioc::*, gpiod::*, gpioe::*, gpiof::*};
 use crate::gpio::{Alternate, AF1, AF10, AF11, AF12, AF2, AF3, AF4, AF5, AF6, AF9};
 
 // This trait marks that a GPIO pin can be used with a specific timer channel
@@ -436,48 +434,26 @@ pins_tuples! {
 macro_rules! pin_impl {
     (CHX: #[ $( $pmeta:meta )* ] $PIN:ident, $ALT:ty, $TIMX:ty, $COMP:ty, $CHANNEL:ty) => {
         $( #[ $pmeta ] )*
-        impl Pins<$TIMX, $CHANNEL, $COMP> for $PIN<Alternate<$ALT>> {
-            type Channel = Pwm<$TIMX, $CHANNEL, $COMP, ActiveHigh, ActiveHigh>;
-        }
-
-        $( #[ $pmeta ] )*
-        #[cfg(feature = "pwm-open-drain")]
-        impl Pins<$TIMX, $CHANNEL, $COMP> for $PIN<AlternateOD<$ALT>> {
+        impl<M> Pins<$TIMX, $CHANNEL, $COMP> for $PIN<Alternate<$ALT, M>> {
             type Channel = Pwm<$TIMX, $CHANNEL, $COMP, ActiveHigh, ActiveHigh>;
         }
     };
 
     (CHXN: #[ $( $pmeta:meta )* ] $PIN:ident, $ALT:ty, $TIMX:ty, $CHANNEL:ty) => {
         $( #[ $pmeta ] )*
-        impl NPins<$TIMX, $CHANNEL> for $PIN<Alternate<$ALT>> {}
-
-        $( #[ $pmeta ] )*
-        #[cfg(feature = "pwm-open-drain")]
-        impl NPins<$TIMX, $CHANNEL> for $PIN<AlternateOD<$ALT>> {}
+        impl<M> NPins<$TIMX, $CHANNEL> for $PIN<Alternate<$ALT, M>> {}
     };
 
     (BRK: #[ $( $pmeta:meta )* ] $PINBRK:ident, $ALTBRK:ty, $TIMX:ty) => {
         $( #[ $pmeta ] )*
-        impl FaultPins<$TIMX> for $PINBRK<Alternate<$ALTBRK>> {
-            const INPUT: BreakInput = BreakInput::BreakIn;
-        }
-
-        $( #[ $pmeta ] )*
-        #[cfg(feature = "pwm-open-drain")]
-        impl FaultPins<$TIMX> for $PINBRK<AlternateOD<$ALTBRK>> {
+        impl<M> FaultPins<$TIMX> for $PINBRK<Alternate<$ALTBRK, M>> {
             const INPUT: BreakInput = BreakInput::BreakIn;
         }
     };
 
     (BRK2: #[ $( $pmeta:meta )* ] $PINBRK2:ident, $ALTBRK2:ty, $TIMX:ty) => {
         $( #[ $pmeta ] )*
-        impl FaultPins<$TIMX> for $PINBRK2<Alternate<$ALTBRK2>> {
-            const INPUT: BreakInput = BreakInput::BreakIn;
-        }
-
-        $( #[ $pmeta ] )*
-        #[cfg(feature = "pwm-open-drain")]
-        impl FaultPins<$TIMX> for $PINBRK2<AlternateOD<$ALTBRK2>> {
+        impl<M> FaultPins<$TIMX> for $PINBRK2<Alternate<$ALTBRK2, M>> {
             const INPUT: BreakInput = BreakInput::BreakIn2;
         }
     };

--- a/src/rcc/clockout.rs
+++ b/src/rcc/clockout.rs
@@ -1,11 +1,11 @@
-use crate::gpio::*;
+use crate::gpio::{self, *};
 use crate::rcc::*;
 use crate::stm32::RCC;
 
 pub type LscoPin = gpioa::PA2<DefaultMode>;
 
-pub struct Lsco {
-    pin: gpioa::PA2<Alternate<AF0>>,
+pub struct Lsco<M=gpio::PushPull> {
+    pin: gpioa::PA2<Alternate<AF0, M>>,
 }
 
 impl Lsco {

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -5,7 +5,7 @@ use crate::dma::{
     mux::DmaMuxResources, traits::TargetAddress, MemoryToPeripheral, PeripheralToMemory,
 };
 use crate::gpio::{gpioa::*, gpiob::*, gpioc::*, gpiod::*, gpioe::*, gpiog::*};
-use crate::gpio::{Alternate, AlternateOD, AF12, AF5, AF7, AF8};
+use crate::gpio::{Alternate, AF12, AF5, AF7, AF8};
 use crate::prelude::*;
 use crate::rcc::{Enable, GetBusFreq, Rcc, RccBus, Reset};
 use crate::stm32::*;
@@ -150,16 +150,12 @@ macro_rules! uart_shared {
 
         $(
             $( #[ $pmeta1 ] )*
-            impl TxPin<$USARTX> for $PTX<Alternate<$TAF>> {
-            }
-            impl TxPin<$USARTX> for $PTX<AlternateOD<$TAF>> {
-            }
+            impl<M> TxPin<$USARTX> for $PTX<Alternate<$TAF, M>> { }
         )+
 
         $(
             $( #[ $pmeta2 ] )*
-            impl RxPin<$USARTX> for $PRX<Alternate<$RAF>> {
-            }
+            impl<M> RxPin<$USARTX> for $PRX<Alternate<$RAF, M>> { }
         )+
 
         impl<Pin, Dma> Rx<$USARTX, Pin, Dma> {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -229,7 +229,7 @@ spi!(
     SPI1,
     spi1,
     sck: [
-        PA5<Alternate<AF5>>,
+        PA5<Alternate<AF5>>, //TODO: Consider making generic over output mode (PushPull/OpenDrain)
         PB3<Alternate<AF5>>,
         #[cfg(any(
             feature = "stm32g471",


### PR DESCRIPTION
This is done with the default output mode being PushPull to be backwards compatible. This also paves the way for having alternate mode with pull up/down resistors in the future.